### PR TITLE
feat: add customer service page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router';
 import Landing from '@/pages/landing/Landing';
-import Footer from '@/shared/footer/Footer';
+import CustomerService from '@/pages/customerservice/CustomerService';
 
 /**
  *
@@ -10,8 +10,8 @@ const App = () => {
     <>
       <Routes>
         <Route path="/" element={<Landing />} />
+        <Route path="/support" element={<CustomerService />} />
       </Routes>
-      <Footer />
     </>
   );
 };

--- a/src/hooks/useNavbar.ts
+++ b/src/hooks/useNavbar.ts
@@ -8,6 +8,10 @@ export const useNavbar = () => {
     navigate('/');
   };
 
+  const goSupport = () => {
+    navigate('/support');
+  };
+
   const handleDownload = () => {
     if (location.pathname === '/') {
       window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -16,5 +20,5 @@ export const useNavbar = () => {
     }
   };
 
-  return { goHome, handleDownload };
+  return { goHome, goSupport, handleDownload };
 };

--- a/src/hooks/useNavbar.ts
+++ b/src/hooks/useNavbar.ts
@@ -20,5 +20,9 @@ export const useNavbar = () => {
     }
   };
 
-  return { goHome, goSupport, handleDownload };
+  const goIntro = () => {
+    navigate('/');
+  };
+
+  return { goHome, goSupport, goIntro, handleDownload };
 };

--- a/src/hooks/useNavbar.ts
+++ b/src/hooks/useNavbar.ts
@@ -1,0 +1,20 @@
+import { useNavigate, useLocation } from 'react-router';
+
+export const useNavbar = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const goHome = () => {
+    navigate('/');
+  };
+
+  const handleDownload = () => {
+    if (location.pathname === '/') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } else {
+      navigate('/');
+    }
+  };
+
+  return { goHome, handleDownload };
+};

--- a/src/pages/customerservice/CustomerService.module.scss
+++ b/src/pages/customerservice/CustomerService.module.scss
@@ -1,0 +1,89 @@
+.container {
+  width: 100%;
+  min-height: 100vh;
+  background-image: url('https://d2ab13l3eziju4.cloudfront.net/frontend/cs1.png');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  display: flex;
+  flex-direction: column;
+}
+
+.main {
+  flex: 1;
+  width: min(1200px, 100% - 48px);
+  margin: 0 auto;
+  padding-top: 180px;
+  padding-bottom: 180px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 48px;
+}
+
+.header {
+  text-align: center;
+
+  h1 {
+    font-size: $font-4xl;
+    font-weight: $font-bold;
+    color: $black;
+    margin-bottom: 12px;
+  }
+
+  p {
+    font-size: $font-lg;
+    color: $gray-5;
+  }
+}
+
+.card {
+  width: min(100%, 480px);
+  background-color: #23272a;
+  border-radius: $radius-5;
+  padding: 48px 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.icon {
+  font-size: 56px;
+  color: $white;
+}
+
+.cardTitle {
+  font-size: $font-2xl;
+  font-weight: $font-bold;
+  color: $white;
+}
+
+.cardDescription {
+  font-size: $font-md;
+  color: #b9bbbe;
+  text-align: center;
+  line-height: 1.6;
+}
+
+.discordButton {
+  margin-top: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background-color: #5865f2;
+  color: $white;
+  font-size: $font-md;
+  font-weight: $font-semibold;
+  padding: 12px 28px;
+  border-radius: $radius-3;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    background-color: #4752c4;
+    transform: translateY(-2px);
+  }
+}

--- a/src/pages/customerservice/CustomerService.tsx
+++ b/src/pages/customerservice/CustomerService.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Navbar from '@/shared/navbar/Navbar';
+import Footer from '@/shared/footer/Footer';
+import styles from '@/pages/customerservice/CustomerService.module.scss';
+import { FaDiscord } from 'react-icons/fa';
+
+const DISCORD_URL = 'https://discord.gg/zMjs9HM3SV';
+
+/**
+ *
+ */
+const CustomerService: React.FC = () => {
+  return (
+    <div className={styles.container}>
+      <Navbar />
+      <main className={styles.main}>
+        <div className={styles.header}>
+          <h1>고객센터</h1>
+          <p>궁금한 점이 있으신가요? 디스코드에서 질문해 주세요.</p>
+        </div>
+
+        <div className={styles.card}>
+          <FaDiscord className={styles.icon} />
+          <p className={styles.cardTitle}>Discord 커뮤니티</p>
+          <p className={styles.cardDescription}>
+            문제 어때 공식 디스코드 채널에서 문의하시면 빠르게 도움을 받으실 수 있어요.
+          </p>
+          <button
+            className={styles.discordButton}
+            onClick={() => window.open(DISCORD_URL, '_blank')}
+          >
+            <FaDiscord />
+            Discord 참여하기
+          </button>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default CustomerService;

--- a/src/pages/landing/Landing.module.scss
+++ b/src/pages/landing/Landing.module.scss
@@ -171,7 +171,7 @@
       width: 7px;
       height: 7px;
       border-radius: $radius-full;
-      background-color: #8E6FD9;
+      background-color: $blue-7
     }
   }
 }

--- a/src/pages/landing/Landing.tsx
+++ b/src/pages/landing/Landing.tsx
@@ -29,6 +29,10 @@ const Landing: React.FC = () => {
   });
 
   useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  useEffect(() => {
     const observerOptions = {
       root: null,
       rootMargin: '0px',

--- a/src/shared/footer/Footer.tsx
+++ b/src/shared/footer/Footer.tsx
@@ -28,7 +28,7 @@ const Footer: React.FC = () => {
 
         <div className={style.githubSection}>
           <a
-            href="https://github.com/khaelim1311"
+            href="https://github.com/haerim-kweon"
             target="_blank"
             rel="noopener noreferrer"
             className={style.githubLink}

--- a/src/shared/navbar/Navbar.tsx
+++ b/src/shared/navbar/Navbar.tsx
@@ -17,7 +17,7 @@ import { useNavbar } from '@/hooks/useNavbar';
  *
  */
 const Navbar: React.FC = () => {
-  const { goHome, goSupport, handleDownload } = useNavbar();
+  const { goHome, goSupport, goIntro, handleDownload } = useNavbar();
 
   return (
     <div className={styles.navbar}>
@@ -26,7 +26,7 @@ const Navbar: React.FC = () => {
         <span className={styles.logoTitle}>문제어때</span>
       </div>
       <div className={styles.navLinks}>
-        <div>소개</div>
+        <div onClick={goIntro}>소개</div>
         <div>도움말</div>
         <div onClick={goSupport}>고객센터</div>
       </div>

--- a/src/shared/navbar/Navbar.tsx
+++ b/src/shared/navbar/Navbar.tsx
@@ -11,11 +11,17 @@
 import React from 'react';
 import CustomButton from '@/shared/custombutton/CustomButton';
 import styles from '@/shared/navbar/Navbar.module.scss';
+import { useNavbar } from '@/hooks/useNavbar';
 
+/**
+ *
+ */
 const Navbar: React.FC = () => {
+  const { goHome, handleDownload } = useNavbar();
+
   return (
     <div className={styles.navbar}>
-      <div className={styles.logoBox}>
+      <div className={styles.logoBox} onClick={goHome} style={{ cursor: 'pointer' }}>
         <img className={styles.logoImage} src="src/assets/images/logo.png" />
         <span className={styles.logoTitle}>문제어때</span>
       </div>
@@ -27,7 +33,7 @@ const Navbar: React.FC = () => {
 
       <div className={styles.actions}>
         {/* <CustomButton text="로그인" variant="primary" size="medium" /> */}
-        <CustomButton text="다운로드" variant="primary" size="medium" />
+        <CustomButton text="다운로드" variant="primary" size="medium" onClick={handleDownload} />
       </div>
     </div>
   );

--- a/src/shared/navbar/Navbar.tsx
+++ b/src/shared/navbar/Navbar.tsx
@@ -17,7 +17,7 @@ import { useNavbar } from '@/hooks/useNavbar';
  *
  */
 const Navbar: React.FC = () => {
-  const { goHome, handleDownload } = useNavbar();
+  const { goHome, goSupport, handleDownload } = useNavbar();
 
   return (
     <div className={styles.navbar}>
@@ -28,7 +28,7 @@ const Navbar: React.FC = () => {
       <div className={styles.navLinks}>
         <div>소개</div>
         <div>도움말</div>
-        <div>고객센터</div>
+        <div onClick={goSupport}>고객센터</div>
       </div>
 
       <div className={styles.actions}>

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -18,6 +18,7 @@ $blue-3:#D5D2FD;
 $blue-4:#C0BDF0;
 $blue-5:#8F8BCC;
 $blue-6:#9583C7;
+$blue-7:#8E6FD9;
 
 $red-1:#FBEDED;
 $red-2:#F8DBDB;


### PR DESCRIPTION
<!-- 
제목은 아래와 같은 커밋 규칙을 따르세요: 
- feat: 새로운 기능
- fix: 버그 수정
- docs: 문서 및 주석 수정
- refactor: 코드 리팩토링 (기능 변화 없음)
- style: css 변경 (로직 변화 없음)
- test: 테스트 코드 추가 또는 수정 
- build: 빌드 설정 
- chore: 기타 사소한 변경
-->


## #️⃣ 관련 이슈
- #15 

## 📝 작업 내용
- 고객센터 페이지를 만들었습니다.
- 푸터는 해당 페이지에 적용하지 않았습니다.(어색함)
- cs는 디스코드로 처리하도록 url을 연결했습니다.(이건 추후 데스크톱 앱에서도 반영할 예정)
- 네비게이션 소개 탭 클릭 시 메인으로 갈 수 있도록 수정했습니다.
- 고객 센터 페이지 전용 배경화면을 적용했습니다.

## ✅ 테스트 결과
- [x] 빌드 테스트
- [x] 디스코드 까지 가는 플로우 확인 

## 💬 리뷰 요구사항(선택)
- 참고) 매번 브랜치 네이밍에 대핸 리소스가 있어서 `구분/#이슈번호` 로 수정했습니다.
